### PR TITLE
Use #error directive shielding against iterator use after erase()

### DIFF
--- a/src/initialization/FGTrimAnalysis.cpp
+++ b/src/initialization/FGTrimAnalysis.cpp
@@ -697,6 +697,8 @@ bool FGTrimAnalysis::RemoveControl( TaControl control ) {
   bool result=false;
 
   mode = taCustom;
+  
+  #error TODO: Iterator is used after erase(). See GH issue #309
   vector <FGTrimAnalysisControl*>::iterator iControls = vTrimAnalysisControls.begin();
   while (iControls != vTrimAnalysisControls.end()) {
       tac=*iControls;


### PR DESCRIPTION
As suggested by Bertrand Coconnier (bcoconni) explicitly not fixing the iterator use after erase() but instead let the compiler exit the compilation if the code is "activated" again.

Rationale: We have no tests in place, so the fix albeit simple would be untested.

Additional info in directive contains link to issue (including the discussion and proposed resolution).