### PR TITLE
Use #error instruction to shield against iterator use after erase()

### DIFF
--- a/src/initialization/FGTrimAnalysis.cpp
+++ b/src/initialization/FGTrimAnalysis.cpp
@@ -725,7 +725,7 @@ bool FGTrimAnalysis::EditState( TaControl new_control, double new_initvalue, dou
       if( tac->GetControlType() == new_control ) {
         vTrimAnalysisControls.insert(iControls,1,new FGTrimAnalysisControl(fdmex,fgic,new_control));
         delete tac;
-        iControls = vTrimAnalysisControls.erase(iControls+1);
+        vTrimAnalysisControls.erase(iControls+1);
         result=true;
         break;
       }


### PR DESCRIPTION
Variant proposed by JSB-Sim team in discussions on issue #309 in upstream repo.

This way we do not push inactive and untested code as fix but instead delegate to compiler alerting when code is activated (the fix then is nearly trivial and well documented inside the referenced issue #309).
