### PR TITLE
Proposal A to resolve issue #312 in upstream repository

### DIFF
--- a/src/input_output/FGXMLElement.cpp
+++ b/src/input_output/FGXMLElement.cpp
@@ -287,10 +287,10 @@ double Element::GetAttributeValueAsNumber(const string& attr)
   string attribute = GetAttributeValue(attr);
 
   if (attribute.empty()) {
-    string const log_message{_concat_to_string(
-      ReadFrom(), "Expecting numeric attribute value, but got no data")};
-    cerr << log_message << endl;
-    throw length_error(log_message);
+    std::stringstream s;
+    s << ReadFrom() << "Expecting numeric attribute value, but got no data";
+    cerr << s.str() << endl;
+    throw length_error(s.str());
   }
   else {
     double number=0;

--- a/src/input_output/FGXMLElement.cpp
+++ b/src/input_output/FGXMLElement.cpp
@@ -29,7 +29,7 @@ INCLUDES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
 #include <sstream>  // for the variadic assembling of error messages.
-#include <stdexcept>  // using domain_error, invalid_argument, and invalid_length.
+#include <stdexcept>  // using domain_error, invalid_argument, and length_error.
 #include "FGXMLElement.h"
 #include "FGJSBBase.h"
 
@@ -290,7 +290,7 @@ double Element::GetAttributeValueAsNumber(const string& attr)
     string const log_message{_concat_to_string(
       ReadFrom(), "Expecting numeric attribute value, but got no data")};
     cerr << log_message << endl;
-    throw invalid_length(log_message);
+    throw length_error(log_message);
   }
   else {
     double number=0;
@@ -362,7 +362,7 @@ double Element::GetDataAsNumber(void)
     string const log_message{_concat_to_string(
       ReadFrom(), "Expected numeric value, but got no data")};
     cerr << log_message << endl;
-    throw invalid_length(log_message);
+    throw length_error(log_message);
   } else {
     cerr << ReadFrom() << "Attempting to get single data value in element "
          << "<" << name << ">" << endl
@@ -372,7 +372,7 @@ double Element::GetDataAsNumber(void)
     string const log_message{_concat_to_string(
       ReadFrom(), "Attempting to get single data value in element ", "<", name, ">",
       " from multiple lines (", data_lines.size(), ").")};
-    throw invalid_length(log_message);
+    throw length_error(log_message);
   }
 }
 
@@ -442,7 +442,7 @@ double Element::FindElementValueAsNumber(const string& el)
     string const log_message{_concat_to_string(
       ReadFrom(), "Attempting to get non-existent element ", el)};
     cerr << log_message << endl;
-    throw invalid_length(log_message);
+    throw length_error(log_message);
   }
 }
 
@@ -490,7 +490,7 @@ double Element::FindElementValueAsNumberConvertTo(const string& el, const string
     string const log_message{_concat_to_string(
       ReadFrom(), "Attempting to get non-existent element ", el)};
     cerr << log_message << endl;
-    throw invalid_length(log_message);
+    throw length_error(log_message);
   }
 
   string supplied_units = element->GetAttributeValue("unit");
@@ -557,7 +557,7 @@ double Element::FindElementValueAsNumberConvertFromTo( const string& el,
     string const log_message{_concat_to_string(
       ReadFrom(), "Attempting to get non-existent element ", el)};
     cerr << log_message << endl;
-    throw invalid_length(log_message);
+    throw length_error(log_message);
   }
 
   if (!supplied_units.empty()) {


### PR DESCRIPTION
This is my first proposal assembling what I understood from the discussions would be a non breaking change enhancing the library posture of [JSBSim](https://github.com/JSBSim-Team/jsbsim).

## Why change?
Be nice as a library and let users decide if an XML parsing error is fatal or not (because only the user knows)

## What does it accomplish?
All `exit(...)` calls could be transformed into exception handling use cases (we throw ...).

## How does it accomplish the transformation?
Use cases mapping:
- emptiness where a value was expected (`length_error`)
- conversion failures because of non-existing conversion rules (`invalid_argument`)
- conversion failures because of value errors (`domain_error`)
- conversion failures because of unknown errors (`invalid_argument`)
- cardinality errors e.g. single value expected, but no value or multiple values found (`length_error`)
- access errors when requesting a non-existing element (`length_error`)

In most cases the error message already built was reused as `what` argument to the exception.

A few cases build elaborate output per multiple values found and these were not translated into the exception argument (to keep these "reason" parameter as a single line with no line end string.

Two new standard library headers are introduced and the rationale is noted as comments in place.

The change also introduces a C++11 helper function that accepts any heterogeneous arguments to collate into an error string. A wrapper comment section has been added to mimic the layout style of the time the source was invented ;-)

## Observable Behavior Changes
In case the execution enters the changed "error handling branches" exceptions are thrown instead of killing the whole process.

Users watching the log via std err will now have repeated cause statements and stack traces in addition to the still written error messages.
The error messages may have been considered part of the public API by some users so this pull request does not touch those.

### Additional Notes
- When changing from C++11 to C++17 the helper function can be greatly simplified (as noted in comments in the function.
- In some places the existing implementation did not exit but instead returned some marker like value and wrote a log message tot eh standard error stream. These places might benefit from revisiting if such silent continuation (for users not watching the console logs) meets the expectation of most library users.
- At least three of the error handling groups could be handled in a central place but for now were kept as is to have a minimal invasive change.
- We could consider removing the log messages when throwing or keeping after surveying use cases of the library?